### PR TITLE
Update LineReader.js

### DIFF
--- a/LineReader.js
+++ b/LineReader.js
@@ -83,7 +83,12 @@ var LineReader = function (options) {
        * incomplete
        */
       if ( self._hasMoreData() ) {
-        internals.chunk = internals.lines.pop();
+    		if (this.result.charAt(this.result.length-1) === '\n') {
+    			internals.chunk = '';
+    		}
+    		else {
+    			internals.chunk = internals.lines.pop();			
+    		}
       }
 
       /**


### PR DESCRIPTION
Whenever this.result ends in a line break (it contains a complete line), it will be concatenated with the next line, ignoring the line break. The changes at line 86 fix this issue (at least for Chrome and Firefox on Windows).