### PR TITLE
the last line was not decoded

### DIFF
--- a/LineReader.js
+++ b/LineReader.js
@@ -111,7 +111,7 @@ var LineReader = function(options) {
        */
       if (internals.chunk.length) {
         return self._emit('line', [
-          internals.chunk,
+          decodeURIComponent(escape(internals.chunk)),
           self._emit.bind(self, 'end'),
         ])
       }


### PR DESCRIPTION
When the last line of text has no newline character, the text is not decoded